### PR TITLE
Set espec dependency to ~> 0.8.0 so it supports minor upgrades

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule EspecPhoenix.Mixfile do
 
   defp deps do
     [
-      {:espec, "0.8.0"},
+      {:espec, "~> 0.8.0"},
       {:phoenix, ">= 0.0.0"},
       {:floki, "~> 0.4.1"}
     ]


### PR DESCRIPTION
Now there's a hard dependency to 0.8.0 version of espec.

This pull request changes it to "~> 0.8.0" so it's going to support minor updates in espec.