### PR TITLE
Evaluate the async keyword in 'use ESpec.Phoenix'

### DIFF
--- a/lib/espec_phoenix.ex
+++ b/lib/espec_phoenix.ex
@@ -1,11 +1,15 @@
 defmodule ESpec.Phoenix do
 
 	defmacro __using__(args) do
+		use_async = case Keyword.has_key?( args, :async ) do
+				true -> Keyword.get( args, :async )
+				_    -> false
+			    end
 		
 		cond do
 			Keyword.has_key?(args, :model) ->
 				quote do
-					use ESpec
+					use ESpec, async: unquote(use_async)
 					@model Keyword.get(unquote(args), :model)
 					
 					import Ecto.Model
@@ -18,7 +22,7 @@ defmodule ESpec.Phoenix do
 		
 			Keyword.has_key?(args, :controller) ->
 				quote do
-					use ESpec
+					use ESpec, async: unquote(use_async)
 					@controller Keyword.get(unquote(args), :controller)
 					
 					use Phoenix.ConnTest
@@ -31,7 +35,7 @@ defmodule ESpec.Phoenix do
 			
 			Keyword.has_key?(args, :request) ->
 				quote do
-					use ESpec
+					use ESpec, async: unquote(use_async)
 					@endpoint Keyword.get(unquote(args), :request)
 					
 					import ESpec.Phoenix.Assertions.Content.Helpers
@@ -46,14 +50,14 @@ defmodule ESpec.Phoenix do
 			
 			Keyword.has_key?(args, :router) ->
 				quote do
-					use ESpec
+					use ESpec, async: unquote(use_async)
 					@router Keyword.get(unquote(args), :router)
 					use ESpec.Phoenix.Extend, :router
 				end	
 
 			Keyword.has_key?(args, :view) ->
 				quote do
-					use ESpec
+					use ESpec, async: unquote(use_async)
 					@view Keyword.get(unquote(args), :view)
 					
 					use Phoenix.ConnTest


### PR DESCRIPTION
With the advent of the parallel sandboxed database connections in ecto 2, async especs make more sense in phoenix apps.

This is a naive extension that just grabs the value of an async keyword in the use ESpec.Phoenix term and passes the value through to the use ESpec term.

Not really sure how to test this, though...