### PR TITLE
Update README instructions for Ecto 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,11 @@ ESpec.start
 
 ESpec.configure fn(config) ->
   config.before fn ->
-    Ecto.Adapters.SQL.Sandbox.checkout(App.Repo, [])
+    Ecto.Adapters.SQL.Sandbox.checkout(App.Repo)
   end
 
   config.finally fn(_shared) ->
-    Ecto.Adapters.SQL.Sandbox(App.Repo, [])
+    Ecto.Adapters.SQL.Sandbox.checkin(App.Repo)
   end
 end
 ```


### PR DESCRIPTION
In order to wrap specs in SQL transactions with Ecto < 2.0 we used
```elixir
Ecto.Adapters.SQL.begin_test_transaction(App.Repo)
```
With Ecto 2.0+ it's deprecated and we're supposed to use [Ecto.Adapters.SQL.Sandbox]( https://hexdocs.pm/ecto/Ecto.Adapters.SQL.Sandbox.html) methods.

This PR is just a clarification and typo fix for eb05bb6595bcd7df2b0afe4062b69bd772e9154f