### PR TITLE
Point badges at Espec.Phoenix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ESpec.Phoenix
-[![Build Status](https://travis-ci.org/antonmi/espec.svg?branch=master)](https://travis-ci.org/antonmi/espec_phoenix)
-[![Hex.pm](https://img.shields.io/hexpm/v/espec.svg?style=flat-square)](https://hex.pm/packages/espec_phoenix)
+[![Build Status](https://travis-ci.org/antonmi/espec_phoenix.svg?branch=master)](https://travis-ci.org/antonmi/espec_phoenix)
+[![Hex.pm](https://img.shields.io/hexpm/v/espec_phoenix.svg?style=flat-square)](https://hex.pm/packages/espec_phoenix)
 
 ##### ESpec helpers for Phoenix web framework.
 


### PR DESCRIPTION
Hi there 👋 First off, thank you _so much_ for writing and maintaining Espec & Espec Phoenix. I use them in nearly all of my Elixir and Phoenix projects 😄 

I noticed that the Hex label was showing a different number than what was on Hex. While the badges were linking to the right place, they are displaying information for Espec regular. This is something that I do by accident _all the time_ in my libs. Here's a quick fix!