### PR TITLE
Fix warnings on Elixir 1.4

### DIFF
--- a/lib/mix/tasks/init.ex
+++ b/lib/mix/tasks/init.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.EspecPhoenix.Init do
 
     app = Mix.Phoenix.base
     create_files(app)
-    patch_espec_config
+    patch_espec_config()
   end
 
   defp create_files(app) do
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.EspecPhoenix.Init do
   end
 
   defp patch_espec_config do
-    append_to Path.join(@spec_folder, @espec_helper), espec_helper_patch_text
+    append_to Path.join(@spec_folder, @espec_helper), espec_helper_patch_text()
   end
 
   defp append_to(filepath, contents) do


### PR DESCRIPTION
Though there are a lot of other warnings for now with Elixir 1.4, this PR fixes the most obvious ones:

```
warning: variable "patch_espec_config" does not exist and is being expanded to "patch_espec_config()", please use parentheses to remove the ambiguity or change the variable name
  lib/mix/tasks/init.ex:27

warning: variable "espec_helper_patch_text" does not exist and is being expanded to "espec_helper_patch_text()", please use parentheses to remove the ambiguity or change the variable name
  lib/mix/tasks/init.ex:36
```