### PR TITLE
Modify init task to properly add Web where its needed 

### DIFF
--- a/lib/mix/tasks/init.ex
+++ b/lib/mix/tasks/init.ex
@@ -61,15 +61,15 @@ defmodule Mix.Tasks.EspecPhoenix.Init do
     def controller do
       quote do
         alias <%= @app %>
-        import <%= @app %>.Router.Helpers
+        import <%= @app %>Web.Router.Helpers
 
-        @endpoint <%= @app %>.Endpoint
+        @endpoint <%= @app %>Web.Endpoint
       end
     end
 
     def view do
       quote do
-        import <%= @app %>.Router.Helpers
+        import <%= @app %>Web.Router.Helpers
       end
     end
 
@@ -77,7 +77,7 @@ defmodule Mix.Tasks.EspecPhoenix.Init do
       quote do
         alias <%= @app %>.Repo
 
-        @endpoint <%= @app %>.Endpoint
+        @endpoint <%= @app %>Web.Endpoint
       end
     end
 

--- a/spec/mix/init_spec.exs
+++ b/spec/mix/init_spec.exs
@@ -73,7 +73,7 @@ defmodule ESpecPhoenixInitSpec do
 
     it "sets @endpoint" do
       expect(content())
-      |> to(have "@endpoint EspecPhoenix.Endpoint")
+      |> to(have "@endpoint EspecPhoenixWeb.Endpoint")
     end
   end
 end


### PR DESCRIPTION
As per issue: https://github.com/antonmi/espec_phoenix/issues/55

This should resolve the issue and make it so that generated files properly point to the correct `Endpoint` and `Routes` module.

Lemme know if I missed anything.